### PR TITLE
change error for out-of-gas to types.OutOfGasError

### DIFF
--- a/api/bindings.h
+++ b/api/bindings.h
@@ -249,9 +249,6 @@ typedef struct {
 
 void destroy_unmanaged_vector(UnmanagedVector v);
 
-/**
- * TODO: wrap sender after PoC: make Context including sender, funds and other contextual information
- */
 UnmanagedVector execute_contract(Db db,
                                  GoApi api,
                                  GoQuerier querier,
@@ -270,7 +267,6 @@ UnmanagedVector new_unmanaged_vector(bool nil, const uint8_t *ptr, size_t length
 
 /**
  * exported function to publish a module
- * TODO: wrap sender after PoC: make Context including sender, funds and other contextual information
  */
 UnmanagedVector publish_module(Db db,
                                bool is_verbose,
@@ -279,9 +275,6 @@ UnmanagedVector publish_module(Db db,
                                ByteSliceView sender,
                                ByteSliceView module);
 
-/**
- * TODO: after PoC: make Context contextual information
- */
 UnmanagedVector query_contract(Db db,
                                GoApi api,
                                GoQuerier querier,

--- a/api/lib.go
+++ b/api/lib.go
@@ -3,6 +3,7 @@ package api
 // #include <stdlib.h>
 // #include "bindings.h"
 import "C"
+
 import (
 	"fmt"
 	"syscall"
@@ -28,7 +29,7 @@ type (
 
 func errorWithMessage(err error, b C.UnmanagedVector) error {
 	// this checks for out of gas as a special case
-	if errno, ok := err.(syscall.Errno); ok && int(errno) == 2 {
+	if errno, ok := err.(syscall.Errno); ok && int(errno) == C.ErrnoValue_OutOfGas {
 		return types.OutOfGasError{}
 	}
 	msg := copyAndDestroyUnmanagedVector(b)

--- a/api/vm.go
+++ b/api/vm.go
@@ -53,7 +53,7 @@ func PublishModule(
 	errmsg := newUnmanagedVector(nil)
 
 	res, err := C.publish_module(db, cbool(isVerbose), cu64(gasLimit), &errmsg, senderView, mb)
-	if err != nil && err.(syscall.Errno) != syscall.Errno(0) /* FIXME: originally it was C.ErrnoValue_Success*/ {
+	if err != nil && err.(syscall.Errno) != C.ErrnoValue_Success {
 		// Depending on the nature of the error, `gasUsed` will either have a meaningful value, or just 0.                                                                            │                                 struct ByteSliceView checksum,
 		return nil, errorWithMessage(err, errmsg)
 	}
@@ -85,7 +85,7 @@ func ExecuteContract(
 	errmsg := newUnmanagedVector(nil)
 
 	res, err := C.execute_contract(db, _api, _querier, cbool(isVerbose), cu64(gasLimit), &errmsg, senderView, msg)
-	if err != nil && err.(syscall.Errno) != syscall.Errno(0) /* FIXME: originally it was C.ErrnoValue_Success*/ {
+	if err != nil && err.(syscall.Errno) != C.ErrnoValue_Success {
 		return nil, errorWithMessage(err, errmsg)
 	}
 
@@ -113,7 +113,7 @@ func QueryContract(
 	errmsg := newUnmanagedVector(nil)
 
 	res, err := C.query_contract(db, _api, _querier, cbool(isVerbose), cu64(gasLimit), &errmsg, msg)
-	if err != nil && err.(syscall.Errno) != syscall.Errno(0) /* FIXME: originally it was C.ErrnoValue_Success*/ {
+	if err != nil && err.(syscall.Errno) != C.ErrnoValue_Success {
 		// Depending on the nature of the error, `gasUsed` will either have a meaningful value, or just 0.                                                                            │                                 struct ByteSliceView checksum,
 		return nil, errorWithMessage(err, errmsg)
 	}

--- a/api/vm.go
+++ b/api/vm.go
@@ -25,7 +25,7 @@ func Initialize(
 	errmsg := newUnmanagedVector(nil)
 
 	res, err := C.initialize(db, cbool(isVerbose), &errmsg, mb)
-	if err != nil && err.(syscall.Errno) != syscall.Errno(0) /* FIXME: originally it was C.ErrnoValue_Success*/ {
+	if err != nil && err.(syscall.Errno) != C.ErrnoValue_Success {
 		// Depending on the nature of the error, `gasUsed` will either have a meaningful value, or just 0.                                                                            │                                 struct ByteSliceView checksum,
 		return nil, errorWithMessage(err, errmsg)
 	}

--- a/lib_test.go
+++ b/lib_test.go
@@ -173,7 +173,7 @@ func Test_OutOfGas(t *testing.T) {
 		payload,
 	)
 	require.NotNil(t, err)
-	require.Contains(t, err.Error(), "OUT_OF_GAS")
+	require.ErrorIs(t, err, types.OutOfGasError{})
 }
 
 func Test_QueryContract(t *testing.T) {

--- a/libnovaproc/Cargo.toml
+++ b/libnovaproc/Cargo.toml
@@ -39,6 +39,7 @@ serde_json = "1.0.85"
 thiserror = "1.0.34"
 novavm = { path = "../vm", features = ["backtraces"] }
 move-deps = { path = "../move-deps", features = ["address20"] }
+log = { version = "0.4.17", features = ["max_level_debug", "release_max_level_warn"] }
 
 [dev-dependencies]
 

--- a/libnovaproc/bindings.h
+++ b/libnovaproc/bindings.h
@@ -249,9 +249,6 @@ typedef struct {
 
 void destroy_unmanaged_vector(UnmanagedVector v);
 
-/**
- * TODO: wrap sender after PoC: make Context including sender, funds and other contextual information
- */
 UnmanagedVector execute_contract(Db db,
                                  GoApi api,
                                  GoQuerier querier,
@@ -270,7 +267,6 @@ UnmanagedVector new_unmanaged_vector(bool nil, const uint8_t *ptr, size_t length
 
 /**
  * exported function to publish a module
- * TODO: wrap sender after PoC: make Context including sender, funds and other contextual information
  */
 UnmanagedVector publish_module(Db db,
                                bool is_verbose,
@@ -279,9 +275,6 @@ UnmanagedVector publish_module(Db db,
                                ByteSliceView sender,
                                ByteSliceView module);
 
-/**
- * TODO: after PoC: make Context contextual information
- */
 UnmanagedVector query_contract(Db db,
                                GoApi api,
                                GoQuerier querier,

--- a/libnovaproc/cbindgen.toml
+++ b/libnovaproc/cbindgen.toml
@@ -60,9 +60,7 @@ usize_is_size_t = true
 # FIXME: not sure why they are not exported by default.
 include = ["ByteSliceView", "U8SliceView", "Db", "db_t", "GoError", "ErrnoValue", "GoApi", "GoQuerier"]
 exclude = []
-# prefix = "CAPI_"
 item_types = []
-#item_types = ["structs", "constants", "globals", "enums", "unions", "typedefs", "opaque", "functions"]
 renaming_overrides_prefixing = false
 
 

--- a/libnovaproc/src/error/rust.rs
+++ b/libnovaproc/src/error/rust.rs
@@ -230,7 +230,6 @@ where
             value.into()
         }
         Err(error) => {
-            log::error!("{:?}", error);
             set_error(error, error_msg);
             Vec::new()
         }

--- a/libnovaproc/src/error/rust.rs
+++ b/libnovaproc/src/error/rust.rs
@@ -223,12 +223,14 @@ pub fn handle_c_error_binary<T>(
 where
     T: Into<Vec<u8>>,
 {
+    // TODO remove this logger
     match result {
         Ok(value) => {
             clear_error();
             value.into()
         }
         Err(error) => {
+            log::error!("{:?}", error);
             set_error(error, error_msg);
             Vec::new()
         }

--- a/libnovaproc/src/interface.rs
+++ b/libnovaproc/src/interface.rs
@@ -24,7 +24,6 @@ pub extern "C" fn initialize(
 }
 
 /// exported function to publish a module
-/// TODO: wrap sender after PoC: make Context including sender, funds and other contextual information
 #[no_mangle]
 pub extern "C" fn publish_module(
     db: Db,
@@ -47,7 +46,6 @@ pub extern "C" fn publish_module(
 }
 
 // exported function to execute (an entrypoint of) contract
-/// TODO: wrap sender after PoC: make Context including sender, funds and other contextual information
 #[no_mangle]
 pub extern "C" fn execute_contract(
     db: Db,
@@ -72,7 +70,6 @@ pub extern "C" fn execute_contract(
 }
 
 // exported function to query contract (in smart way)
-/// TODO: after PoC: make Context contextual information
 #[no_mangle]
 pub extern "C" fn query_contract(
     db: Db,

--- a/libnovaproc/src/querier.rs
+++ b/libnovaproc/src/querier.rs
@@ -1,7 +1,10 @@
 use crate::error::GoError;
 use crate::memory::{U8SliceView, UnmanagedVector};
 
+use novavm::BackendError;
 use novavm::backend::{BackendResult, Querier};
+
+use log::info;
 
 // this represents something passed in from the caller side of FFI
 #[repr(C)]
@@ -64,15 +67,8 @@ impl Querier for GoQuerier {
 
         let bin_result: Vec<u8> = output.unwrap_or_default();
         let result = serde_json::from_slice(&bin_result).or_else(|e| {
-            todo!() 
-		  // FIXME: put it as stub
-			/* original.. remove it after porting  
-			Ok(SystemResult::Err(SystemError::InvalidResponse {
-				error: format!("Parsing Go response: {}", e),
-				response: bin_result.into(),
-			}))
-		});
-		*/
+            info!("failed to deserialize query result: {:?}", e);
+            Err(BackendError::invalid_utf8())
          });
         result
     }

--- a/libnovaproc/src/querier.rs
+++ b/libnovaproc/src/querier.rs
@@ -39,7 +39,7 @@ impl Querier for GoQuerier {
     fn query_raw(
         &self,
         request: &[u8],
-    ) -> BackendResult<Vec<u8>> { /* FIXME: put Vec<u8> as stub */
+    ) -> BackendResult<Vec<u8>> {
         let mut output = UnmanagedVector::default();
         let mut error_msg = UnmanagedVector::default();
         let go_result: GoError = (self.vtable.query_external)(

--- a/libnovaproc/src/storage.rs
+++ b/libnovaproc/src/storage.rs
@@ -46,7 +46,7 @@ impl GoStorage {
 
 impl StateView for GoStorage {
         fn get(&self, access_path: &AccessPath) -> anyhow::Result<Option<Vec<u8>>> {
-        let key = access_path.to_string(); // FIXME: replace to_string to to_cosmos_key
+        let key = access_path.to_string();
         let mut output = UnmanagedVector::default();
         let mut error_msg = UnmanagedVector::default();
         let go_error: GoError = (self.db.vtable.read_db)(

--- a/vm/src/errors/backend_error.rs
+++ b/vm/src/errors/backend_error.rs
@@ -12,8 +12,6 @@ pub enum BackendError {
     BadArgument {},
     #[error("VM received invalid UTF-8 data from backend")]
     InvalidUtf8 {},
-    #[error("Iterator with ID {id} does not exist")]
-    IteratorDoesNotExist { id: u32 },
     #[error("Ran out of gas during call into backend")]
     OutOfGas {},
     #[error("Unimplemented")]
@@ -34,9 +32,10 @@ impl BackendError {
         BackendError::BadArgument {}
     }
 
-    pub fn iterator_does_not_exist(iterator_id: u32) -> Self {
-        BackendError::IteratorDoesNotExist { id: iterator_id }
+    pub fn invalid_utf8() -> Self {
+        BackendError::InvalidUtf8 {}
     }
+
 
     pub fn out_of_gas() -> Self {
         BackendError::OutOfGas {}

--- a/vm/src/errors/mod.rs
+++ b/vm/src/errors/mod.rs
@@ -3,5 +3,3 @@ mod vm_error;
 
 pub use backend_error::BackendError;
 pub use vm_error::NovaVMError;
-
-pub type VmResult<T> = core::result::Result<T, NovaVMError>;

--- a/vm/src/errors/vm_error.rs
+++ b/vm/src/errors/vm_error.rs
@@ -26,8 +26,9 @@ impl NovaVMError {
     }
 
     pub(crate) fn move_error(status: VMStatus) -> Self {
-        NovaVMError::MoveError{
-            status
+        match &status.status_code() {
+            StatusCode::OUT_OF_GAS => NovaVMError::gas_depletion(),
+            _ => NovaVMError::MoveError { status }
         }
     }
 
@@ -41,16 +42,6 @@ impl NovaVMError {
 
 impl From<VMStatus> for NovaVMError {
     fn from(source: VMStatus) -> Self {
-         match &source{
-            VMStatus::ExecutionFailure { status_code, location, function, code_offset } => {
-                match status_code {
-                    StatusCode::OUT_OF_GAS => {
-                        NovaVMError::gas_depletion()
-                    },
-                    _ => NovaVMError::move_error(source)
-                }
-            },
-            _ => NovaVMError::move_error(source)
-        }
+        NovaVMError::move_error(source)
     }
 }


### PR DESCRIPTION
now vm functions (on go-side) returns  `types.OutOfGasError{}` to handle that error in more smooth way.