### PR TITLE
feat: invalidate loader cache function

### DIFF
--- a/vm/src/nova_vm.rs
+++ b/vm/src/nova_vm.rs
@@ -91,7 +91,7 @@ impl NovaVM {
     /// outdated. This can happen if the adapter executed a particular code publishing transaction
     /// but decided to not commit the result to the data store. Because the code cache currently
     /// does not support deletion, the cache will, incorrectly, still contain this module.
-    pub fn invalidate_loader_cache(self) {
+    pub fn invalidate_loader_cache(&self) {
         self.move_vm.mark_loader_cache_as_invalid();
     }
 

--- a/vm/src/tests/mock_chain.rs
+++ b/vm/src/tests/mock_chain.rs
@@ -1,0 +1,72 @@
+use crate::{access_path::AccessPath, storage::state_view::StateView};
+use std::collections::BTreeMap;
+
+use move_deps::move_core_types::{
+    effects::{ChangeSet, Op},
+    language_storage::ModuleId,
+};
+
+pub struct MockChain {
+    map: BTreeMap<AccessPath, Option<Vec<u8>>>,
+}
+impl MockChain {
+    pub fn new() -> Self {
+        Self {
+            map: BTreeMap::new(),
+        }
+    }
+
+    // not scalable because it simply clones current map
+    pub fn create_state(&self) -> MockState {
+        MockState {
+            map: self.map.clone(),
+        }
+    }
+
+    pub fn commit(&mut self, state: MockState) {
+        self.map = state.map;
+    }
+}
+
+//faking chain db
+pub struct MockState {
+    map: BTreeMap<AccessPath, Option<Vec<u8>>>,
+}
+
+impl MockState {
+    fn write_op(&mut self, ref ap: AccessPath, ref blob_opt: Op<Vec<u8>>) {
+        match blob_opt {
+            Op::New(blob) | Op::Modify(blob) => {
+                self.map.insert(ap.clone(), Some(blob.clone()));
+            }
+            Op::Delete => {
+                self.map.remove(ap);
+                self.map.insert(ap.clone(), None);
+            }
+        }
+    }
+
+    pub fn push_write_set(&mut self, changeset: ChangeSet) {
+        for (addr, account_changeset) in changeset.into_inner() {
+            let (modules, resources) = account_changeset.into_inner();
+            for (struct_tag, blob_opt) in resources {
+                let ap = AccessPath::resource_access_path(addr, struct_tag);
+                self.write_op(ap, blob_opt)
+            }
+
+            for (name, blob_opt) in modules {
+                let ap = AccessPath::from(&ModuleId::new(addr, name));
+                self.write_op(ap, blob_opt)
+            }
+        }
+    }
+}
+
+impl StateView for MockState {
+    fn get(&self, access_path: &AccessPath) -> anyhow::Result<Option<Vec<u8>>> {
+        match self.map.get(access_path) {
+            Some(opt_data) => Ok(opt_data.clone()),
+            None => Ok(None),
+        }
+    }
+}

--- a/vm/src/tests/mock_chain.rs
+++ b/vm/src/tests/mock_chain.rs
@@ -28,7 +28,6 @@ impl MockChain {
     }
 }
 
-//faking chain db
 pub struct MockState {
     map: BTreeMap<AccessPath, Option<Vec<u8>>>,
 }

--- a/vm/src/tests/mock_tx.rs
+++ b/vm/src/tests/mock_tx.rs
@@ -3,35 +3,35 @@ use move_deps::move_core_types::vm_status::VMStatus;
 use crate::Message;
 
 pub struct MockTx {
-    pub test_msgs: Vec<(Message, ExpectedOutput)>,
+    pub msg_tests: Vec<(Message, ExpectedOutput)>,
     pub should_commit: bool,
 }
 
 impl MockTx {
     pub fn one(msg: Message, exp_output: ExpectedOutput) -> Self {
         Self {
-            test_msgs: vec![(msg, exp_output)],
+            msg_tests: vec![(msg, exp_output)],
             should_commit: true,
         }
     }
 
     pub fn one_skip_commit(msg: Message, exp_output: ExpectedOutput) -> Self {
         Self {
-            test_msgs: vec![(msg, exp_output)],
+            msg_tests: vec![(msg, exp_output)],
             should_commit: false,
         }
     }
 
-    pub fn new(test_msgs: Vec<(Message, ExpectedOutput)>) -> Self {
+    pub fn new(msg_tests: Vec<(Message, ExpectedOutput)>) -> Self {
         Self {
-            test_msgs,
+            msg_tests,
             should_commit: true,
         }
     }
 
-    pub fn new_skip_commit(test_msgs: Vec<(Message, ExpectedOutput)>) -> Self {
+    pub fn new_skip_commit(msg_tests: Vec<(Message, ExpectedOutput)>) -> Self {
         Self {
-            test_msgs,
+            msg_tests,
             should_commit: false,
         }
     }

--- a/vm/src/tests/mock_tx.rs
+++ b/vm/src/tests/mock_tx.rs
@@ -1,0 +1,66 @@
+use move_deps::move_core_types::vm_status::VMStatus;
+
+use crate::Message;
+
+pub struct MockTx {
+    pub test_msgs: Vec<(Message, ExpectedOutput)>,
+    pub should_commit: bool,
+}
+
+impl MockTx {
+    pub fn one(msg: Message, exp_output: ExpectedOutput) -> Self {
+        Self {
+            test_msgs: vec![(msg, exp_output)],
+            should_commit: true,
+        }
+    }
+
+    pub fn one_skip_commit(msg: Message, exp_output: ExpectedOutput) -> Self {
+        Self {
+            test_msgs: vec![(msg, exp_output)],
+            should_commit: false,
+        }
+    }
+
+    pub fn new(test_msgs: Vec<(Message, ExpectedOutput)>) -> Self {
+        Self {
+            test_msgs,
+            should_commit: true,
+        }
+    }
+
+    pub fn new_skip_commit(test_msgs: Vec<(Message, ExpectedOutput)>) -> Self {
+        Self {
+            test_msgs,
+            should_commit: false,
+        }
+    }
+}
+
+pub struct ExpectedOutput {
+    vm_status: VMStatus,
+    changed_accounts: usize,
+    result_bytes: Option<Vec<u8>>,
+}
+impl ExpectedOutput {
+    pub fn new(
+        vm_status: VMStatus,
+        changed_accounts: usize,
+        result_bytes: Option<Vec<u8>>,
+    ) -> Self {
+        ExpectedOutput {
+            vm_status,
+            changed_accounts,
+            result_bytes,
+        }
+    }
+    pub fn vm_status(&self) -> &VMStatus {
+        &self.vm_status
+    }
+    pub fn changed_accounts(&self) -> usize {
+        self.changed_accounts
+    }
+    pub fn result_bytes(&self) -> &Option<Vec<u8>> {
+        &self.result_bytes
+    }
+}

--- a/vm/src/tests/mod.rs
+++ b/vm/src/tests/mod.rs
@@ -2,3 +2,4 @@ pub mod simple_transaction_tests;
 pub mod vm_error_tests;
 
 mod mock_chain;
+mod mock_tx;

--- a/vm/src/tests/mod.rs
+++ b/vm/src/tests/mod.rs
@@ -1,2 +1,4 @@
 pub mod simple_transaction_tests;
 pub mod vm_error_tests;
+
+mod mock_chain;

--- a/vm/src/tests/simple_transaction_tests.rs
+++ b/vm/src/tests/simple_transaction_tests.rs
@@ -230,7 +230,9 @@ fn run_transaction(testcases: Vec<(Message, ExpectedOutput)>) {
     let gas_limit = Gas::new(100_000u64);
     for (msg, exp_output) in testcases {
         let resolver = DataViewResolver::new(&db);
-        let (status, output, result) = vm.execute_message(msg, &resolver, gas_limit).expect("nova vm failure");
+        let (status, output, result) = vm
+            .execute_message(msg, &resolver, gas_limit)
+            .expect("nova vm failure");
         println!("gas used: {}", output.gas_used());
         println!("got:{}, exp:{}", status, exp_output.vm_status());
         assert!(status == *exp_output.vm_status());
@@ -244,6 +246,9 @@ fn run_transaction(testcases: Vec<(Message, ExpectedOutput)>) {
         }
         // apply output into db
         db.push_write_set(output.change_set().clone());
+
+        // TODO: mock tx rollback
+        vm.invalidate_loader_cache();
     }
 }
 

--- a/vm/src/tests/simple_transaction_tests.rs
+++ b/vm/src/tests/simple_transaction_tests.rs
@@ -1,18 +1,14 @@
 use crate::{
-    access_path::AccessPath,
     gas::Gas,
     message::{EntryFunction, Message, Module, ModuleBundle, Script},
     nova_vm::NovaVM,
     storage::data_view_resolver::DataViewResolver,
-    storage::state_view::StateView,
 };
-use std::collections::BTreeMap;
 
 use move_deps::{
     move_binary_format::CompiledModule,
     move_core_types::{
         account_address::AccountAddress,
-        effects::{ChangeSet, Op},
         identifier::Identifier,
         language_storage::{ModuleId, TypeTag},
         parser::parse_struct_tag,
@@ -23,55 +19,6 @@ use move_deps::{
 use crate::asset::{
     compile_move_nursery_modules, compile_move_stdlib_modules, compile_nova_stdlib_modules,
 };
-
-//faking chain db
-struct MockDB {
-    map: BTreeMap<AccessPath, Option<Vec<u8>>>,
-}
-
-impl MockDB {
-    pub fn new() -> Self {
-        Self {
-            map: BTreeMap::new(),
-        }
-    }
-
-    fn write_op(&mut self, ref ap: AccessPath, ref blob_opt: Op<Vec<u8>>) {
-        match blob_opt {
-            Op::New(blob) | Op::Modify(blob) => {
-                self.map.insert(ap.clone(), Some(blob.clone()));
-            }
-            Op::Delete => {
-                self.map.remove(ap);
-                self.map.insert(ap.clone(), None);
-            }
-        }
-    }
-
-    pub fn push_write_set(&mut self, changeset: ChangeSet) {
-        for (addr, account_changeset) in changeset.into_inner() {
-            let (modules, resources) = account_changeset.into_inner();
-            for (struct_tag, blob_opt) in resources {
-                let ap = AccessPath::resource_access_path(addr, struct_tag);
-                self.write_op(ap, blob_opt)
-            }
-
-            for (name, blob_opt) in modules {
-                let ap = AccessPath::from(&ModuleId::new(addr, name));
-                self.write_op(ap, blob_opt)
-            }
-        }
-    }
-}
-
-impl StateView for MockDB {
-    fn get(&self, access_path: &AccessPath) -> anyhow::Result<Option<Vec<u8>>> {
-        match self.map.get(access_path) {
-            Some(opt_data) => Ok(opt_data.clone()),
-            None => Ok(None),
-        }
-    }
-}
 
 #[cfg(test)]
 impl Module {
@@ -206,7 +153,9 @@ impl ExpectedOutput {
 }
 
 fn run_transaction(testcases: Vec<(Message, ExpectedOutput)>) {
-    let mut db = MockDB::new();
+    use super::mock_chain::MockChain;
+
+    let mut chain = MockChain::new();
     let mut vm = NovaVM::new();
 
     // publish move_stdlib and move_nursery and nova_stdlib modules
@@ -214,8 +163,9 @@ fn run_transaction(testcases: Vec<(Message, ExpectedOutput)>) {
     modules.append(&mut compile_move_nursery_modules());
     modules.append(&mut compile_nova_stdlib_modules());
 
+    let mut state = chain.create_state();
     for module in modules {
-        let resolver = DataViewResolver::new(&db);
+        let resolver = DataViewResolver::new(&state);
         let mut mod_blob = vec![];
         module
             .serialize(&mut mod_blob)
@@ -224,12 +174,14 @@ fn run_transaction(testcases: Vec<(Message, ExpectedOutput)>) {
             .initialize(mod_blob, &resolver)
             .expect("Module must load");
         assert!(status == VMStatus::Executed);
-        db.push_write_set(output.change_set().clone());
+        state.push_write_set(output.change_set().clone());
     }
+    chain.commit(state);
 
     let gas_limit = Gas::new(100_000u64);
     for (msg, exp_output) in testcases {
-        let resolver = DataViewResolver::new(&db);
+        let mut state = chain.create_state();
+        let resolver = DataViewResolver::new(&state);
         let (status, output, result) = vm
             .execute_message(msg, &resolver, gas_limit)
             .expect("nova vm failure");
@@ -245,7 +197,9 @@ fn run_transaction(testcases: Vec<(Message, ExpectedOutput)>) {
             continue;
         }
         // apply output into db
-        db.push_write_set(output.change_set().clone());
+        state.push_write_set(output.change_set().clone());
+
+        chain.commit(state);
 
         // TODO: mock tx rollback
         vm.invalidate_loader_cache();

--- a/vm/src/tests/simple_transaction_tests.rs
+++ b/vm/src/tests/simple_transaction_tests.rs
@@ -153,14 +153,14 @@ fn run_transaction(testcases: Vec<MockTx>) {
 
     let gas_limit = Gas::new(100_000u64);
     for MockTx {
-        test_msgs,
+        msg_tests,
         should_commit,
     } in testcases
     {
         let mut state = chain.create_state();
         let mut module_published = false;
 
-        for (msg, exp_output) in test_msgs {
+        for (msg, exp_output) in msg_tests {
             if matches!(msg.payload(), MessagePayload::ModuleBundle(_)) {
                 module_published = true;
             }


### PR DESCRIPTION
- Adds an interface to invalidate loader cache.
  - This should be called when a transaction including module publish message is abandoned.
- Tests for the interface
  - MockDB is changed into MockChain and MockState
    - MockChain mocks BlockChain storage
    - MockState mocks State and it is temporary while transaction and can be commited into storage or disposed.

