### PR TITLE
add std::coin tests

### DIFF
--- a/vm/move-test/sources/StdCoin.move
+++ b/vm/move-test/sources/StdCoin.move
@@ -1,0 +1,36 @@
+module 0x2::StdCoin {
+    use 0x1::coin;
+    use std::string;
+    use std::signer;
+    use std::debug;
+
+    struct Std {}
+
+    struct CapStore has key{
+        burn: coin::BurnCapability<Std>,
+        freeze: coin::FreezeCapability<Std>,
+        mint: coin::MintCapability<Std>
+    }
+
+    entry fun init(sender: &signer) {
+        let (burn, freeze, mint) = coin::initialize<Std>(sender, string::utf8(b"Std Coin"), string::utf8(b"STDC"), 8);
+
+        move_to(sender, CapStore {
+            burn, freeze, mint
+        });
+    }
+
+
+    entry fun register(sender: &signer) {
+        coin::register<Std>(sender);
+    }
+
+    entry fun mint(sender: &signer, account_to: address, amount: u64)  acquires CapStore {
+        let sender_address = signer::address_of(sender);
+        let caps = borrow_global<CapStore>(sender_address);
+        
+        let minted = coin::mint(amount, &caps.mint);
+        debug::print(&coin::value<Std>(&minted));
+        coin::deposit(account_to, minted);
+    }
+}

--- a/vm/src/tests/mock_tx.rs
+++ b/vm/src/tests/mock_tx.rs
@@ -1,18 +1,10 @@
-use super::{mock_chain::MockChain};
+use super::mock_chain::MockChain;
 
 use crate::{
-    message::{Message},
-    gas::Gas,
-    nova_vm::NovaVM,
-    storage::data_view_resolver::DataViewResolver,
+    gas::Gas, message::Message, nova_vm::NovaVM, storage::data_view_resolver::DataViewResolver,
 };
 
-use move_deps::{
-    move_core_types::{
-        vm_status::{VMStatus},
-    },
-};
-
+use move_deps::move_core_types::vm_status::VMStatus;
 
 pub struct MockTx {
     pub msg_tests: Vec<(Message, ExpectedOutput)>,
@@ -80,7 +72,6 @@ impl ExpectedOutput {
     }
 }
 
-
 pub fn run_transaction(testcases: Vec<MockTx>) {
     let mut chain = MockChain::new();
     let mut vm = NovaVM::new();
@@ -98,6 +89,7 @@ pub fn run_transaction(testcases: Vec<MockTx>) {
         should_commit,
     } in testcases
     {
+        println!("tx start");
         let mut state = chain.create_state();
 
         for (msg, exp_output) in msg_tests {
@@ -113,15 +105,15 @@ pub fn run_transaction(testcases: Vec<MockTx>) {
 
             let result_bytes =
                 result.map(|r| r.return_values.first().map_or(vec![], |m| m.0.clone()));
-            
-            println!("result_bytes: {:?}", result_bytes);            
+
+            println!("result_bytes: {:?}", result_bytes);
             assert!(result_bytes == *exp_output.result_bytes());
 
             if status != VMStatus::Executed {
                 continue;
             }
             // apply output into state
-            state.push_write_set(output.change_set().clone(),output.table_change_set());
+            state.push_write_set(output.change_set().clone(), output.table_change_set());
         }
 
         if should_commit {

--- a/vm/src/tests/mod.rs
+++ b/vm/src/tests/mod.rs
@@ -1,6 +1,7 @@
-pub mod simple_transaction_tests;
-pub mod vm_error_tests;
-pub mod table_tests;
-pub mod move_unit_tests;
 mod mock_chain;
 mod mock_tx;
+pub mod move_unit_tests;
+pub mod table_tests;
+pub mod tx_simple_tests;
+pub mod tx_std_coin_tests;
+pub mod vm_error_tests;

--- a/vm/src/tests/simple_transaction_tests.rs
+++ b/vm/src/tests/simple_transaction_tests.rs
@@ -1,6 +1,4 @@
-use crate::{
-    message::{EntryFunction, Message, Module, ModuleBundle, Script},
-};
+use crate::message::{EntryFunction, Message, Module, ModuleBundle, Script};
 
 use move_deps::{
     move_binary_format::CompiledModule,
@@ -13,8 +11,8 @@ use move_deps::{
     },
 };
 
-use super::mock_tx::{MockTx, run_transaction};
-use super::{mock_tx::ExpectedOutput};
+use super::mock_tx::ExpectedOutput;
+use super::mock_tx::{run_transaction, MockTx};
 
 #[cfg(test)]
 impl Module {
@@ -29,6 +27,12 @@ impl Module {
 
     fn get_basic_coin_module_id() -> ModuleId {
         ModuleId::new(AccountAddress::ONE, Identifier::new("BasicCoin").unwrap())
+    }
+
+    fn create_std_coin() -> Self {
+        Self::new(
+            include_bytes!("../../move-test/build/test1/bytecode_modules/StdCoin.mv").to_vec(),
+        )
     }
 }
 
@@ -174,6 +178,85 @@ fn test_module_upgrade_loader_cache() {
             // should work with new module
             Message::new_entry_function(vec![4; 32],Some(account_two), EntryFunction::mint(100)),
             ExpectedOutput::new(VMStatus::Executed, 1, Some(vec![])),
+        ),
+    ];
+
+    run_transaction(testcases);
+}
+#[test]
+fn test_std_coin() {
+    let account_one =
+        AccountAddress::from_hex_literal("0x1").expect("0x1 account should be created");
+    let account_two =
+        AccountAddress::from_hex_literal("0x2").expect("0x2 account should be created");
+    let account_three =
+        AccountAddress::from_hex_literal("0x3").expect("0x3 account should be created");
+
+    let testcases: Vec<MockTx> = vec![
+        MockTx::one(
+            // publish
+            Message::new_module(
+                vec![1; 32],
+                Some(account_two),
+                ModuleBundle::from(Module::create_std_coin()),
+            ),
+            ExpectedOutput::new(VMStatus::Executed, 1, None),
+        ),
+        MockTx::one(
+            // initialize coin and capabilities
+            Message::new_entry_function(
+                vec![2; 32],
+                Some(account_two),
+                EntryFunction::new(
+                    ModuleId::new(account_two, Identifier::new("StdCoin").unwrap()),
+                    Identifier::new("init").unwrap(),
+                    vec![],
+                    vec![],
+                ),
+            ),
+            ExpectedOutput::new(VMStatus::Executed, 1, Some(vec![])),
+        ),
+        MockTx::one(
+            // register account #3 to receive coin
+            Message::new_entry_function(
+                vec![3; 32],
+                Some(account_three),
+                EntryFunction::new(
+                    ModuleId::new(account_two, Identifier::new("StdCoin").unwrap()),
+                    Identifier::new("register").unwrap(),
+                    vec![],
+                    vec![],
+                ),
+            ),
+            ExpectedOutput::new(VMStatus::Executed, 1, Some(vec![])),
+        ),
+        MockTx::one(
+            Message::new_entry_function(
+                vec![4; 32],
+                Some(account_two),
+                EntryFunction::new(
+                    ModuleId::new(account_two, Identifier::new("StdCoin").unwrap()),
+                    Identifier::new("mint").unwrap(),
+                    vec![],
+                    vec![account_three.to_vec(), 100u64.to_le_bytes().to_vec()],
+                ),
+            ),
+            ExpectedOutput::new(VMStatus::Executed, 2, Some(vec![])),
+        ),
+        MockTx::one(
+            Message::new_entry_function(
+                vec![5; 32],
+                None,
+                EntryFunction::new(
+                    ModuleId::new(account_one, Identifier::new("coin").unwrap()),
+                    Identifier::new("balance").unwrap(),
+                    vec![TypeTag::Struct(
+                        parse_struct_tag("0x2::StdCoin::Std").unwrap(),
+                    )],
+                    vec![account_three.to_vec()],
+                ),
+            ),
+            ExpectedOutput::new(VMStatus::Executed, 0, Some(vec![100, 0, 0, 0, 0, 0, 0, 0])),
         ),
     ];
 

--- a/vm/src/tests/tx_simple_tests.rs
+++ b/vm/src/tests/tx_simple_tests.rs
@@ -28,12 +28,6 @@ impl Module {
     fn get_basic_coin_module_id() -> ModuleId {
         ModuleId::new(AccountAddress::ONE, Identifier::new("BasicCoin").unwrap())
     }
-
-    fn create_std_coin() -> Self {
-        Self::new(
-            include_bytes!("../../move-test/build/test1/bytecode_modules/StdCoin.mv").to_vec(),
-        )
-    }
 }
 
 #[cfg(test)]
@@ -178,85 +172,6 @@ fn test_module_upgrade_loader_cache() {
             // should work with new module
             Message::new_entry_function(vec![4; 32],Some(account_two), EntryFunction::mint(100)),
             ExpectedOutput::new(VMStatus::Executed, 1, Some(vec![])),
-        ),
-    ];
-
-    run_transaction(testcases);
-}
-#[test]
-fn test_std_coin() {
-    let account_one =
-        AccountAddress::from_hex_literal("0x1").expect("0x1 account should be created");
-    let account_two =
-        AccountAddress::from_hex_literal("0x2").expect("0x2 account should be created");
-    let account_three =
-        AccountAddress::from_hex_literal("0x3").expect("0x3 account should be created");
-
-    let testcases: Vec<MockTx> = vec![
-        MockTx::one(
-            // publish
-            Message::new_module(
-                vec![1; 32],
-                Some(account_two),
-                ModuleBundle::from(Module::create_std_coin()),
-            ),
-            ExpectedOutput::new(VMStatus::Executed, 1, None),
-        ),
-        MockTx::one(
-            // initialize coin and capabilities
-            Message::new_entry_function(
-                vec![2; 32],
-                Some(account_two),
-                EntryFunction::new(
-                    ModuleId::new(account_two, Identifier::new("StdCoin").unwrap()),
-                    Identifier::new("init").unwrap(),
-                    vec![],
-                    vec![],
-                ),
-            ),
-            ExpectedOutput::new(VMStatus::Executed, 1, Some(vec![])),
-        ),
-        MockTx::one(
-            // register account #3 to receive coin
-            Message::new_entry_function(
-                vec![3; 32],
-                Some(account_three),
-                EntryFunction::new(
-                    ModuleId::new(account_two, Identifier::new("StdCoin").unwrap()),
-                    Identifier::new("register").unwrap(),
-                    vec![],
-                    vec![],
-                ),
-            ),
-            ExpectedOutput::new(VMStatus::Executed, 1, Some(vec![])),
-        ),
-        MockTx::one(
-            Message::new_entry_function(
-                vec![4; 32],
-                Some(account_two),
-                EntryFunction::new(
-                    ModuleId::new(account_two, Identifier::new("StdCoin").unwrap()),
-                    Identifier::new("mint").unwrap(),
-                    vec![],
-                    vec![account_three.to_vec(), 100u64.to_le_bytes().to_vec()],
-                ),
-            ),
-            ExpectedOutput::new(VMStatus::Executed, 2, Some(vec![])),
-        ),
-        MockTx::one(
-            Message::new_entry_function(
-                vec![5; 32],
-                None,
-                EntryFunction::new(
-                    ModuleId::new(account_one, Identifier::new("coin").unwrap()),
-                    Identifier::new("balance").unwrap(),
-                    vec![TypeTag::Struct(
-                        parse_struct_tag("0x2::StdCoin::Std").unwrap(),
-                    )],
-                    vec![account_three.to_vec()],
-                ),
-            ),
-            ExpectedOutput::new(VMStatus::Executed, 0, Some(vec![100, 0, 0, 0, 0, 0, 0, 0])),
         ),
     ];
 

--- a/vm/src/tests/tx_std_coin_tests.rs
+++ b/vm/src/tests/tx_std_coin_tests.rs
@@ -1,0 +1,106 @@
+use crate::message::{EntryFunction, Message, Module, ModuleBundle};
+
+use move_deps::move_core_types::{
+    account_address::AccountAddress,
+    identifier::Identifier,
+    language_storage::{ModuleId, TypeTag},
+    parser::parse_struct_tag,
+    vm_status::VMStatus,
+};
+
+use super::mock_tx::ExpectedOutput;
+use super::mock_tx::{run_transaction, MockTx};
+
+#[cfg(test)]
+impl Module {
+    fn create_std_coin() -> Self {
+        Self::new(
+            include_bytes!("../../move-test/build/test1/bytecode_modules/StdCoin.mv").to_vec(),
+        )
+    }
+}
+
+#[cfg(test)]
+impl EntryFunction {}
+
+#[test]
+fn test_std_coin() {
+    let account_one =
+        AccountAddress::from_hex_literal("0x1").expect("0x1 account should be created");
+    let account_two =
+        AccountAddress::from_hex_literal("0x2").expect("0x2 account should be created");
+    let account_three =
+        AccountAddress::from_hex_literal("0x3").expect("0x3 account should be created");
+
+    let testcases: Vec<MockTx> = vec![
+        MockTx::one(
+            // publish
+            Message::new_module(
+                vec![1; 32],
+                Some(account_two),
+                ModuleBundle::from(Module::create_std_coin()),
+            ),
+            ExpectedOutput::new(VMStatus::Executed, 1, None),
+        ),
+        MockTx::one(
+            // initialize coin and capabilities
+            Message::new_entry_function(
+                vec![2; 32],
+                Some(account_two),
+                EntryFunction::new(
+                    ModuleId::new(account_two, Identifier::new("StdCoin").unwrap()),
+                    Identifier::new("init").unwrap(),
+                    vec![],
+                    vec![],
+                ),
+            ),
+            ExpectedOutput::new(VMStatus::Executed, 1, Some(vec![])),
+        ),
+        MockTx::one(
+            // register 0x3 to receive coin
+            Message::new_entry_function(
+                vec![3; 32],
+                Some(account_three),
+                EntryFunction::new(
+                    ModuleId::new(account_two, Identifier::new("StdCoin").unwrap()),
+                    Identifier::new("register").unwrap(),
+                    vec![],
+                    vec![],
+                ),
+            ),
+            ExpectedOutput::new(VMStatus::Executed, 1, Some(vec![])),
+        ),
+        MockTx::one(
+            // mint coin to 0x3
+            Message::new_entry_function(
+                vec![4; 32],
+                Some(account_two),
+                EntryFunction::new(
+                    ModuleId::new(account_two, Identifier::new("StdCoin").unwrap()),
+                    Identifier::new("mint").unwrap(),
+                    vec![],
+                    vec![account_three.to_vec(), 100u64.to_le_bytes().to_vec()],
+                ),
+            ),
+            ExpectedOutput::new(VMStatus::Executed, 2, Some(vec![])),
+        ),
+        MockTx::one(
+            // get 0x3's balance
+            Message::new_entry_function(
+                vec![5; 32],
+                None,
+                EntryFunction::new(
+                    ModuleId::new(account_one, Identifier::new("coin").unwrap()),
+                    Identifier::new("balance").unwrap(),
+                    vec![TypeTag::Struct(
+                        parse_struct_tag("0x2::StdCoin::Std").unwrap(),
+                    )],
+                    vec![account_three.to_vec()],
+                ),
+            ),
+            ExpectedOutput::new(VMStatus::Executed, 0, Some(vec![100, 0, 0, 0, 0, 0, 0, 0])),
+        ),
+    ];
+
+    run_transaction(testcases);
+}


### PR DESCRIPTION
This PR adds tests for `StdCoin` module leverages `std::coin`.

One of main target of this test is to check effects on multiple accounts with single message.
(`vm/src/tests/tx_std_coin_tests.rs#85`)