### PR TITLE
Fix: compiler has no native context

### DIFF
--- a/compiler/src/compiler.rs
+++ b/compiler/src/compiler.rs
@@ -1,14 +1,19 @@
 // from move-language/move/tools/move-cli/src/lib.rs
 // SPDX-License-Identifier: Apache-2.0
+use crate::mock::{BlankStorage, MockApi};
 use anyhow::bail;
-use move_deps::move_cli::Move;
+use clap::__macro_refs::once_cell::sync::Lazy;
 use move_deps::move_cli::base::{build::Build, test::Test};
-use move_deps::move_core_types::{
-    account_address::AccountAddress, identifier::Identifier,
-};
+use move_deps::move_cli::Move;
+use move_deps::move_core_types::{account_address::AccountAddress, identifier::Identifier};
+use move_deps::move_unit_test;
+use move_deps::move_vm_runtime::native_extensions::NativeContextExtensions;
 use move_deps::move_vm_runtime::native_functions::NativeFunction;
 use novavm::gas::NativeGasParameters;
+use novavm::natives::block::NativeBlockContext;
+use novavm::natives::code::NativeCodeContext;
 use novavm::natives::nova_natives;
+use novavm::natives::table::NativeTableContext;
 
 use std::fmt;
 
@@ -47,25 +52,37 @@ fn run_compiler(
         Command::Clean(c) => c.execute(move_args.package_path),
     }
 }
+pub fn configure_for_unit_test() {
+    move_unit_test::extensions::set_extension_hook(Box::new(unit_test_extensions_hook))
+}
+
+static DUMMY_RESOLVER: Lazy<BlankStorage> = Lazy::new(|| BlankStorage);
+
+fn unit_test_extensions_hook(exts: &mut NativeContextExtensions) {
+    exts.add(NativeCodeContext::default());
+    exts.add(NativeTableContext::new([0; 32], &*DUMMY_RESOLVER));
+    exts.add(NativeBlockContext::new(&MockApi {
+        height: 100,
+        timestamp: 100,
+    }));
+}
 
 // works as entrypoint
-pub fn compile(
-    move_args: Move,
-    cmd: Command,
-) -> anyhow::Result<Vec<u8>> {
+pub fn compile(move_args: Move, cmd: Command) -> anyhow::Result<Vec<u8>> {
     //let cost_table = &INITIAL_COST_SCHEDULE;
     //let error_descriptions: ErrorMapping = bcs::from_bytes(move_stdlib::error_descriptions()).unwrap();
     let natives = nova_natives(NativeGasParameters::zeros());
+    configure_for_unit_test();
 
     let res = run_compiler(
         natives,
         //cost_table,
         //&error_descriptions,
         move_args,
-        cmd
+        cmd,
     );
     match res {
-        Ok(_r) => Ok(Vec::from("ok")),  // FIXME: do we have to return some valuable contents?
-        Err(e ) => bail!(e.to_string())
+        Ok(_r) => Ok(Vec::from("ok")), // FIXME: do we have to return some valuable contents?
+        Err(e) => bail!(e.to_string()),
     }
 }

--- a/compiler/src/lib.rs
+++ b/compiler/src/lib.rs
@@ -1,13 +1,15 @@
 #![cfg_attr(feature = "backtraces", feature(backtrace))]
 #![allow(clippy::not_unsafe_ptr_arg_deref, clippy::missing_safety_doc)]
 
-pub mod compiler;
 pub mod clean;
+pub mod compiler;
 pub mod new;
 
-pub use compiler::{compile, Command};
 pub use clean::Clean;
+pub use compiler::{compile, Command};
 pub use new::New;
+
+mod mock;
 
 #[cfg(test)]
 mod tests;

--- a/compiler/src/mock.rs
+++ b/compiler/src/mock.rs
@@ -1,0 +1,61 @@
+use anyhow::Error;
+use move_deps::move_core_types::{
+    account_address::AccountAddress,
+    language_storage::{ModuleId, StructTag},
+    resolver::{ModuleResolver, ResourceResolver},
+};
+use novavm::{
+    api::ChainApi,
+    natives::table::{TableHandle, TableResolver},
+};
+
+pub struct MockApi {
+    pub height: u64,
+    pub timestamp: u64,
+}
+
+impl ChainApi for MockApi {
+    fn get_block_info(&self) -> anyhow::Result<(u64 /* height */, u64 /* timestamp */)> {
+        Ok((self.height, self.timestamp))
+    }
+}
+
+/// A dummy storage containing no modules or resources.
+#[derive(Debug, Clone)]
+pub struct BlankStorage;
+
+impl BlankStorage {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl ModuleResolver for BlankStorage {
+    type Error = ();
+
+    fn get_module(&self, _module_id: &ModuleId) -> Result<Option<Vec<u8>>, Self::Error> {
+        Ok(None)
+    }
+}
+
+impl ResourceResolver for BlankStorage {
+    type Error = ();
+
+    fn get_resource(
+        &self,
+        _address: &AccountAddress,
+        _tag: &StructTag,
+    ) -> Result<Option<Vec<u8>>, Self::Error> {
+        Ok(None)
+    }
+}
+
+impl TableResolver for BlankStorage {
+    fn resolve_table_entry(
+        &self,
+        _handle: &TableHandle,
+        _key: &[u8],
+    ) -> Result<Option<Vec<u8>>, Error> {
+        Ok(None)
+    }
+}


### PR DESCRIPTION
This sets native contexts (like NativeTableContext, NativeBlockContext, ...) into NativeContextExtensions before compiler test runs VM.

Some mocking codes are duplicated with VM's test code.

I wanted to packages the common mocking codes, however, it turned out packaging is a big task because of serial & circular dependency (gas, natives, message...).
